### PR TITLE
misc: edits for new version of python 3.11

### DIFF
--- a/custom_components/setter/__init__.py
+++ b/custom_components/setter/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import asyncio
 
 from homeassistant.core import Context
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -78,9 +77,9 @@ class SaverEntity(RestoreEntity):
     def state(self):
         return len(self._entities_db)
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
-        state = yield from self.async_get_last_state()
+    #@asyncio.coroutine
+    async def async_added_to_hass(self):
+        state = await self.async_get_last_state()
         if (
             state is not None
             and state.attributes is not None

--- a/custom_components/setter/manifest.json
+++ b/custom_components/setter/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/dlashua/hass-setter",
   "issue_tracker": "https://github.com/dlashua/hass-setter/issues",
   "dependencies": [],
-  "codeowners": ["@dlashua"],
+  "codeowners": ["@dlashua", "@ThePrincelle"],
   "requirements": [],
   "config_flow": true
 }

--- a/custom_components/setter/manifest.json
+++ b/custom_components/setter/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/dlashua/hass-setter",
   "issue_tracker": "https://github.com/dlashua/hass-setter/issues",
   "dependencies": [],
-  "codeowners": ["@dlashua", "@ThePrincelle"],
+  "codeowners": ["@dlashua"],
   "requirements": [],
   "config_flow": true
 }


### PR DESCRIPTION
This PR changes some things for the newest versions of Home Assistant and Python. 

It fixes an issue where `asyncio.coroutine` is deprecated.